### PR TITLE
Lower minimum server API version to 5.0 for greater compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,9 +41,9 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",

--- a/task/task.json
+++ b/task/task.json
@@ -10,6 +10,7 @@
   "category": "Azure Pipelines",
   "visibility": ["Build"],
   "runsOn": ["Agent"],
+  "minimumAgentVersion": "3.232.1",
   "author": "Rhys Koedijk",
   "version": {
     "Major": 0,

--- a/ui/sbom-report-tab.tsx
+++ b/ui/sbom-report-tab.tsx
@@ -3,13 +3,14 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
 import { CommonServiceIds, getClient, IProjectPageService } from 'azure-devops-extension-api';
-import { BuildRestClient, BuildServiceIds, IBuildPageDataService } from 'azure-devops-extension-api/Build';
+import { BuildServiceIds, IBuildPageDataService } from 'azure-devops-extension-api/Build';
 import { Spinner } from 'azure-devops-ui/Spinner';
 import { ZeroData } from 'azure-devops-ui/ZeroData';
 
 import { SpdxDocumentPage } from './components/SpdxDocumentPage';
 import { ISpdx22Document } from './models/Spdx22';
 
+import { BuildRestClient } from './utils/BuildRestClient';
 import './utils/StringExtensions';
 
 import './sbom-report-tab.scss';

--- a/ui/utils/BuildRestClient.tsx
+++ b/ui/utils/BuildRestClient.tsx
@@ -1,0 +1,64 @@
+import { IVssRestClientOptions } from 'azure-devops-extension-api/Common';
+import { RestClientBase } from 'azure-devops-extension-api/Common/RestClientBase';
+
+import * as Build from 'azure-devops-extension-api/Build';
+
+export class BuildRestClient extends RestClientBase {
+  constructor(options: IVssRestClientOptions) {
+    super(options);
+  }
+
+  public static readonly API_VERSION = '5.0';
+
+  /**
+   * Gets the list of attachments of a specific type that are associated with a build.
+   *
+   * @param project - Project ID or project name
+   * @param buildId - The ID of the build.
+   * @param type - The type of attachment.
+   */
+  public async getAttachments(project: string, buildId: number, type: string): Promise<Build.Attachment[]> {
+    return this.beginRequest<Build.Attachment[]>({
+      apiVersion: BuildRestClient.API_VERSION,
+      routeTemplate: '{project}/_apis/build/builds/{buildId}/attachments/{type}',
+      routeValues: {
+        project: project,
+        buildId: buildId,
+        type: type,
+      },
+    });
+  }
+
+  /**
+   * Gets a specific attachment.
+   *
+   * @param project - Project ID or project name
+   * @param buildId - The ID of the build.
+   * @param timelineId - The ID of the timeline.
+   * @param recordId - The ID of the timeline record.
+   * @param type - The type of the attachment.
+   * @param name - The name of the attachment.
+   */
+  public async getAttachment(
+    project: string,
+    buildId: number,
+    timelineId: string,
+    recordId: string,
+    type: string,
+    name: string,
+  ): Promise<ArrayBuffer> {
+    return this.beginRequest<ArrayBuffer>({
+      apiVersion: BuildRestClient.API_VERSION,
+      httpResponseType: 'application/octet-stream',
+      routeTemplate: '{project}/_apis/build/builds/{buildId}/{timelineId}/{recordId}/attachments/{type}/{name}',
+      routeValues: {
+        project: project,
+        buildId: buildId,
+        timelineId: timelineId,
+        recordId: recordId,
+        type: type,
+        name: name,
+      },
+    });
+  }
+}

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -13,6 +13,7 @@
       "id": "Microsoft.VisualStudio.Services"
     }
   ],
+  "demands": ["api-version/5.0"],
   "categories": ["Azure Pipelines"],
   "tags": [
     "sbom",


### PR DESCRIPTION
- Update vulnerable packages
- Require minimum agent version 3.232.1
- Require minimum server API version 5.0
- Use server API version 5.0 with BuildRestClient