### PR TITLE
Fixed version parameter usage in sbomTool.ts

### DIFF
--- a/task/utils/sbomTool.ts
+++ b/task/utils/sbomTool.ts
@@ -265,7 +265,7 @@ async function installToolLinuxAsync(directory: string, architecture?: string, v
     await tool(which('bash', true))
       .arg([
         '-c',
-        `curl "${GITHUB_RELEASES_URL}/${version ? 'v' + version : 'latest'}/download/sbom-tool-linux-${architecture}" -Lo "${toolPath}" && chmod +x "${toolPath}"`,
+        `curl "${GITHUB_RELEASES_URL}/${version ? 'download/v' + version : 'latest/download'}/sbom-tool-linux-${architecture}" -Lo "${toolPath}" && chmod +x "${toolPath}"`,
       ])
       .execAsync();
     return toolPath;


### PR DESCRIPTION
Please take a look at this change as soon as possible — without it, the production environment pipelines are blocked (https://github.com/rhyskoedijk/sbom-azure-devops/issues/173).