### PR TITLE
fix: Switch recursive call to iterative to resolve "Maximum call stac…

### DIFF
--- a/task/utils/spdx/convertSpdxToSvg.ts
+++ b/task/utils/spdx/convertSpdxToSvg.ts
@@ -160,7 +160,15 @@ export async function convertSpdxToSvgAsync(spdx: IDocument): Promise<Buffer> {
 
   // Export the graph as SVG text
   console.info(`Writing SVG image`);
-  return Buffer.from(positioned.to_svg().to_string(), 'utf8');
+  try {
+    const svg = positioned.to_svg();
+    return Buffer.from(svg.to_string(), 'utf8');
+  }
+  catch (error: unknown) {
+    // If SVG generation fails, return a minimal valid SVG
+    console.warn(`Failed to generate SVG image.  ${ (error as Error)?.message }`);
+    return Buffer.from(`<?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>`, 'utf8');
+  }
 }
 
 function graphFileAndParentDirectoriesRecursive(


### PR DESCRIPTION
On several of our large projects, we started getting the following error:

```
RangeError: Maximum call stack size exceeded
    at getPackageAncestorPathsRecursive (webpack:///../shared/spdx/models/2.3/document.ts?:76:37)
    at eval (webpack:///../shared/spdx/models/2.3/document.ts?:48:96)
    at Array.flatMap (<anonymous>)
    at getPackageAncestorDependencyPaths (webpack:///../shared/spdx/models/2.3/document.ts?:48:70)
    at eval (webpack:///../shared/spdx/convertSpdxToXlsx.ts?:182:95)
    at Array.map (<anonymous>)
    at eval (webpack:///../shared/spdx/convertSpdxToXlsx.ts?:170:18)
    at Generator.next (<anonymous>)
    at eval (webpack:///../shared/spdx/convertSpdxToXlsx.ts?:41:71)
    at new Promise (<anonymous>)
```
    
 Switch recursive function to iterative to resolve.