### PR TITLE
Add support for "licenseInformationTimeoutInSeconds" cli arg

### DIFF
--- a/task/index.ts
+++ b/task/index.ts
@@ -49,6 +49,7 @@ async function run() {
               enableManifestGraphGeneration: getBoolInput('enableManifestGraphGeneration', false),
               enablePackageMetadataParsing: getBoolInput('enablePackageMetadataParsing', false),
               fetchLicenseInformation: getBoolInput('fetchLicenseInformation', false),
+              licenseInformationTimeoutInSeconds: getInput('licenseInformationTimeoutInSeconds', false),
               fetchSecurityAdvisories: getBoolInput('fetchSecurityAdvisories', false),
               gitHubAccessToken: getGithubAccessToken(),
               packageName:

--- a/task/task.json
+++ b/task/task.json
@@ -115,6 +115,15 @@
       "visibleRule": "command=generate"
     },
     {
+      "name": "licenseInformationTimeoutInSeconds",
+      "type": "string",
+      "label": "License Information Timeout (Seconds)",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Specifies the timeout in seconds for fetching the license information. Defaults to 30 seconds. Has no effect if the `fetchLicenseInformation` argument is false or not provided. A negative value corresponds to an infinite timeout.",
+      "visibleRule": "command=generate"
+    },
+    {
       "name": "fetchSecurityAdvisories",
       "type": "boolean",
       "label": "Fetch Security Advisory Information",

--- a/task/utils/sbomTool.ts
+++ b/task/utils/sbomTool.ts
@@ -31,6 +31,7 @@ export interface SbomToolGenerateArgs {
   enableManifestGraphGeneration?: boolean;
   enablePackageMetadataParsing?: boolean;
   fetchLicenseInformation?: boolean;
+  licenseInformationTimeoutInSeconds?: string;
   fetchSecurityAdvisories?: boolean;
   gitHubAccessToken?: string;
   packageName: string;
@@ -96,6 +97,9 @@ export class SbomTool {
       }
       if (args.fetchLicenseInformation) {
         sbomToolArguments.push('-li', 'true');
+        if (args.licenseInformationTimeoutInSeconds) {
+          sbomToolArguments.push('-lto', args.licenseInformationTimeoutInSeconds);
+        }
       }
       sbomToolArguments.push('-pn', args.packageName);
       sbomToolArguments.push('-pv', args.packageVersion);


### PR DESCRIPTION
This PR makes a small update to expose the ``LicenseInformationTimeoutInSeconds`` argument that was recently added to the sbom-tool CLI (see [microsoft/sbom-tool#773](https://github.com/microsoft/sbom-tool/pull/773)), released in version 3.1.0.

I've been hitting timeout issues in my pipelines when fetching license information, as the default timeout is too short. This change exposes the ``-lto`` flag, allowing users to extend that duration directly from the task configuration.